### PR TITLE
Fix handling of min and max values for percentages

### DIFF
--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -62,16 +62,24 @@ class Metric:
             self.critical = guess_int_or_float(r.group(5))
             self.min = guess_int_or_float(r.group(6))
             self.max = guess_int_or_float(r.group(7))
+            self.min_specified = self.min is not None
+            self.max_specified = self.max is not None
             # print 'Name', self.name
             # print "Value", self.value
             # print "Res", r
             # print r.groups()
             if self.uom == '%':
-                self.min = 0
-                self.max = 100
+                self.min = self.min if self.min_specified is not None else 0
+                self.max = self.max if self.max_specified is not None else 100
 
     def __str__(self):
-        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, self.min, self.max]
+        min = self.min if self.min_specified else None
+        max = self.max if self.max_specified else None
+        prefix =  "min=%s, max=%s" % (min, max)
+        if self.uom == '%':
+            min = None if (self.min == 0) and not self.min_specified else min
+            max = None if (self.max == 100) and not self.max_specified else max
+        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, min, max]
         while components[-1] is None:
             components.pop()
         return ";".join(map(lambda v: "" if v is None else str(v), components))
@@ -99,3 +107,4 @@ class PerfDatas:
 
     def __contains__(self, key):
         return key in self.metrics
+

--- a/test/test_string_perfdata.py
+++ b/test/test_string_perfdata.py
@@ -61,6 +61,22 @@ class TestStringPerfdata(ShinkenTest):
         self.assertEqual('ramused=1009MB;;;0', str(Metric('ramused=1009MB;;;0')))
         self.assertEqual('ramused=1009MB;;;;0', str(Metric('ramused=1009MB;;;;0')))
 
+    def test_string_percent_minmaxdefault_0_100(self):
+        # If not specified, defaults of 0 and 100 for min/max should not come back
+        self.assertEqual('utilization=80%;90;95', str(Metric('utilization=80%;90;95')))
+        self.assertEqual('utilization=80%;90;95;;', str(Metric('utilization=80%;90;95')) + ";;")
+
+    def test_string_percent_minmax_echo(self):
+        # Defined values of min max should come back always, even if defaults
+        self.assertEqual('utilization=80%;50;75;0;100', str(Metric('utilization=80%;50;75;0;100')))
+        self.assertEqual('utilization=80%;50;75;0', str(Metric('utilization=80%;50;75;0')))
+        self.assertEqual('utilization=80%;50;75;;100', str(Metric('utilization=80%;50;75;;100')))
+
+        # Same tests with non-default values
+        self.assertEqual('utilization=80%;50;75;85;95', str(Metric('utilization=80%;50;75;85;95')))
+        self.assertEqual('utilization=80%;50;75;85', str(Metric('utilization=80%;50;75;85')))
+        self.assertEqual('utilization=80%;50;75;;95', str(Metric('utilization=80%;50;75;;95')))
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
When to uom is % min and max were always forced to 0. This causes graphs to always have 0 and 100 for min and max, even if other values were supplied.

This is changed to only force the default values if no other values had been set.

In addition, when converting a Metric to a string, those same min and max values were always included. If they are actually 0 and 100 that is not necessary, and they are now left out, but only if not explicitly specified on input.

These changes allow control over the appearance of min and max lines in graphs, regardless of their desired values. If the value is specified, even when equal to a default, they will be output and thus graphed. If defaults were generated, they will not be graphed.

This leaves the semantics of the perfdata unchanged.
